### PR TITLE
Added YouTube Shorts Recommendation Support

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -38,6 +38,7 @@ function main() {
     style.addCSSRule('tp-yt-app-drawer', 'visibility: hidden  !important;')
     style.addCSSRule('#secondary', 'visibility: hidden  !important;')
     style.addCSSRule('#end', 'visibility: hidden  !important;')
+    style.addCSSRule('ytd-rich-shelf-renderer', 'visibility: hidden  !important;'); // YouTube Shorts Recommendation
     hasInserted = true
   }
 


### PR DESCRIPTION
YouTube recommendation (with selector: ytd-rich-shelf-renderer) isn't supported yet, I added the support for it.